### PR TITLE
VI Bug: had two for loops in wrong order

### DIFF
--- a/experiments/pickle_jar/VI_planning_horizon_baselines.txt
+++ b/experiments/pickle_jar/VI_planning_horizon_baselines.txt
@@ -67,7 +67,8 @@ agent - ave time/epoch: 1493.21905613
 
 Process finished with exit code 0
 
-Planning horizon = 8 agent
+Benchmarks:
+Planning horizon = 8
 
 epochs: 100
 ave undiscounted return: 4.64183638127 +- 0.62487622734

--- a/pomdpy/solvers/linear_alpha_net.py
+++ b/pomdpy/solvers/linear_alpha_net.py
@@ -44,7 +44,6 @@ class LinearAlphaNet(BaseTFSolver):
         start_step = self.step_assign_op.eval({self.step_input: epoch * self.model.max_steps})
 
         total_reward, avg_reward_per_step, total_loss, total_v, total_delta = 0., 0., 0., 0., 0.
-        avg_loss, avg_v, avg_delta = 0., 0., 0.
         actions = []
 
         # Reset for new run

--- a/pomdpy/solvers/value_iteration.py
+++ b/pomdpy/solvers/value_iteration.py
@@ -58,12 +58,12 @@ class ValueIteration(Solver):
             # add (|A| * |V|^|Z|) alpha-vectors to gamma, |V| is |gamma_k|
             for u in range(actions):
                 c = self.compute_indices(idx, observations)
-                for indices in c:
-                    temp = np.zeros(states)
-                    for i in range(states):
-                        for z in range(observations):
+                for indices in c:  # n elements in c is |V|^|Z|
+                    for z in range(observations):
+                        temp = np.zeros(states)
+                        for i in range(states):
                             temp[i] = discount * (r[u][i] + v_new[indices[z]][u][z][i])
-                    gamma_k.add(AlphaVector(a=u, v=temp))
+                        gamma_k.add(AlphaVector(a=u, v=temp))
             self.gamma.update(gamma_k)
             if first:
                 # remove the dummy alpha vector


### PR DESCRIPTION
Didn't affect benchmarks, because Tiger problem
has dynamics that are symmetric for each of 2 states