### PR TITLE
Bugfix: Wrong results for Value Iteration

### DIFF
--- a/pomdpy/solvers/value_iteration.py
+++ b/pomdpy/solvers/value_iteration.py
@@ -53,7 +53,7 @@ class ValueIteration(Solver):
                         for j in range(states):
                             for i in range(states):
                                 # v_i_k * p(z | x_i, u) * p(x_i | u, x_j)
-                                v_new[idx][u][z][i] = v.v[i] * o[u][i][z] * t[u][j][i]
+                                v_new[idx][u][z][j] = v.v[i] * o[u][i][z] * t[u][j][i]
                 idx += 1
             # add (|A| * |V|^|Z|) alpha-vectors to gamma, |V| is |gamma_k|
             for u in range(actions):


### PR DESCRIPTION
The value iteration results are wrong as can be seen by the fact that they're supposed to be symmetric. 
This change fixes the bug.

Explanation: The line should backpropagate the value at the new state `i`, i.e. `v.v[i]` to the old state `j`, i.e. to `v_new[idx][u][z][j]`.